### PR TITLE
fixing checkreadme.py bug

### DIFF
--- a/genctf.py
+++ b/genctf.py
@@ -37,7 +37,7 @@ rootpre += """
 * <TODO>
 * [Scoreboard](TODO) or [local alternative](TODOLOCAL)
 
-## Repo-local write-ups
+## Completed write-ups
 
 * none yet
 


### PR DESCRIPTION
checkreadme.py copies orignal README.md unitl reading "## Completed write-ups".
Generating a write-up folder with genctf.py causes a messed up README.md, due to use 
"## Repo-local write-ups" instead of "## Completed write-ups".
